### PR TITLE
MapSearchContainer 正则表达式小问题

### DIFF
--- a/src/app/core/service/MapService/map.service.ts
+++ b/src/app/core/service/MapService/map.service.ts
@@ -16,7 +16,7 @@ export class MapService {
 
     constructor(private http: HttpClient) {}
 
-    getMapInfo(sid: number): Observable<MapSidDetail> {
+    getMapInfo(sid: number | string): Observable<MapSidDetail> {
         const params = new HttpParams({ fromString: `0=${sid}` });
         return this.http
             .get(`${this.BASE_URL}/v2/beatmapinfo`, {

--- a/src/app/pages/home/map-search/map-search-container/map-search-container.component.ts
+++ b/src/app/pages/home/map-search/map-search-container/map-search-container.component.ts
@@ -67,13 +67,13 @@ export class MapSearchContainerComponent implements OnInit {
 
     search(keyWords: any) {
         this.keywords = keyWords
-            .replace(/["]/gi, '')
-            .replace(/(^\s*)|(\s*$)/gi, '');
+            .replace(/"/g, '')
+            .trim();
         this.typeCode = 4;
         this.offset = 0;
 
         // 是否数字，是的话直接请求单个铺面，否的话请求列表
-        if (this.keywords.match(/[\d]/gi)) {
+        if (this.keywords.match(/^\d+$|\/\d+/)) {
             this.mapServe
                 .getMapInfo(this.keywords)
                 .subscribe((res: MapSidDetail) => {


### PR DESCRIPTION
有一个很烦人的问题，<strong>如果搜索词里有数字，会被默认是搜索谱面编号</strong>。有些情况下曲名里是有数字的，这一判断<strong>会导致无法正常搜索</strong>。于是我就找到了这个 repo 尝试修复一下这个问题。

我注意到程序只是简单地<strong>检查输入里是否有数字</strong>，如果有数字就调用“<def>谱面详情 v2</def>”API（按谱面或谱组编号搜索），否则调用“<def>谱面列表</def>”API 按关键词搜索。又去查了 API 文档，发现“谱面详情v2”只接受 SID、BID 或网址，看来目前的判断调用哪个 API 的方法不对，<strong>应该是判断搜索词是否是数字或网址</strong>。

我假定当且仅当用户输入<strong>纯数字 SID</strong>、<strong>谱面网址</strong>或像 <samp>/beatmapsets/123456</samp>、<samp>/s/123456</samp>、<samp>/b/123456</samp> 这样<strong>省略域名的短网址</strong>时才按 ID 搜索。于是把判断调用哪个 API 的方法改为：如果输入的是<strong>纯数字</strong>，或<strong>数字紧跟在斜杠后面</strong>就调用“谱面详情 v2”获取相应 ID 的谱面，否则调用“谱面列表”按关键词搜索。

我认为我的方案可以解决<em>大多数</em>“搜索关键词里有数字”的问题，但不排除某些较为怪异的曲名或艺人名里可能有数字紧跟在斜杠后面（[/s/222119](https://osu.ppy.sh/beatmapsets/222119)）。

本人没有任何 TypeScript 和 Angular 的实际使用经验，但只是改个正则表达式（已本地测试）应该不会出问题吧（×）。望采纳。